### PR TITLE
ci: add automation to update release branches on GitHub releases

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -1,0 +1,25 @@
+# Automatically updates "vX" branches based on GitHub releases. To cut a new
+# release, use the GitHub UI where you enter a tag name and release name of
+# "vX.Y.Z". See https://github.com/jupyterhub/action-k8s-namespace-report/releases.
+---
+name: Release updates
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: windows-latest
+    steps:
+      # Action reference: https://github.com/Actions-R-Us/actions-tagger
+      # NOTE: We pin a version not to have the source code (.ts files), but the
+      #       compiled source code (.js files). This git hash is what v2.0.1
+      #       referenced 30 December 2020.
+      - uses: Actions-R-Us/actions-tagger@95c51c646e75db5c6b7d447e3087bcee58677341
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"
+        with:
+          # By using branches as identifiers it is still possible to backtrack
+          # some patch, but not if we use tags.
+          prefer_branch_releases: true


### PR DESCRIPTION
Closes #59 by adding automation to update v1 branches etc when a GitHub Release is made/updated.
