### PR TITLE
Add CHANGELOG.md for a v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+### v1.1.0 - 2021-04-15
+
+([full changelog](https://github.com/jupyterhub/action-major-minor-tag-calculator/compare/v1.0.0...81e90594b90bef0bc68479d0ab3aae33a940526e))
+
+#### New features added
+
+- If no github ref is found optionally return a default tag [#66](https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/66) ([@manics](https://github.com/manics))
+
+#### Bugs fixed
+
+- Pre-release handling [#64](https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/64) ([@jburel](https://github.com/jburel))
+- Handle empty ref [#38](https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/38) ([@manics](https://github.com/manics))
+
+#### Maintenance and upkeep improvements
+
+- Update License from boilerplate entry to JupyterHub [#63](https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/63) ([@consideRatio](https://github.com/consideRatio))
+
+#### Documentation improvements
+
+- Update README to assume a less introduced reader [#65](https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/65) ([@consideRatio](https://github.com/consideRatio))
+
+#### Continuous integration improvements
+
+- ci: add automation to update release branches on GitHub releases [#62](https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/62) ([@consideRatio](https://github.com/consideRatio))
+
+#### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/action-major-minor-tag-calculator/graphs/contributors?from=2021-02-10&to=2021-04-15&type=c))
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Faction-major-minor-tag-calculator+involves%3AconsideRatio+updated%3A2021-02-10..2021-04-15&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterhub%2Faction-major-minor-tag-calculator+involves%3Adependabot+updated%3A2021-02-10..2021-04-15&type=Issues) | [@jburel](https://github.com/search?q=repo%3Ajupyterhub%2Faction-major-minor-tag-calculator+involves%3Ajburel+updated%3A2021-02-10..2021-04-15&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Faction-major-minor-tag-calculator+involves%3Amanics+updated%3A2021-02-10..2021-04-15&type=Issues)


### PR DESCRIPTION
@manics I saw https://github.com/jupyterhub/jupyterhub/pull/3425 required a PR to be merged, so I figured I'll prep a release with a CHANGELOG etc.