### PR TITLE
Set permissions.contents=write in workflows

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   actions-tagger:
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
       # NOTE: We pin a version not to have the source code (.ts files), but the

--- a/.github/workflows/test-and-update.yml
+++ b/.github/workflows/test-and-update.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test-and-update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       # Runs format, updates dist, runs tests


### PR DESCRIPTION
Adds `write` permissions for the `GITHUB_TOKEN` in the two update workflows so we can set the default permission at the org level to `read`:
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
- https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
- https://github.com/jupyterhub/team-compass/issues/398#issuecomment-823459878