### PR TITLE
Remove deprecated `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -19,8 +19,6 @@ jobs:
       #       compiled source code (.js files). This git hash is what v2.0.1
       #       referenced 30 December 2020.
       - uses: Actions-R-Us/actions-tagger@f411bd910a5ad370d4511517e3eac7ff887c90ea
-        env:
-          GITHUB_TOKEN: "${{ github.token }}"
         with:
           # By using branches as identifiers it is still possible to backtrack
           # some patch, but not if we use tags.


### PR DESCRIPTION
Default is `${{ github.token }}`: https://github.com/Actions-R-Us/actions-tagger/tree/v2.0.2#token

See logs in https://github.com/jupyterhub/action-major-minor-tag-calculator/runs/4054750120?check_suite_focus=true