### PR TITLE
ci: add pre-commit-config with prettier and eslint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# Common tasks
+#
+# - Run on all files:   pre-commit run --all-files
+# - Register git hooks: pre-commit install --install-hooks
+#
+repos:
+  # Autoformat: javascript, markdown, yaml, json
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
+    hooks:
+      - id: prettier
+
+  # Lint: javascript
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.5.0
+    hooks:
+      - id: eslint
+        # These are not pinned to avoid manual maintenance up updating them, at
+        # the same time, they could cause a failure if something breaking is
+        # introduced.
+        additional_dependencies:
+          - eslint
+          - eslint-plugin-jest
+          - jest


### PR DESCRIPTION
Hmmm, not sure about this. I went a bit on autopilot adding pre-commit-config.yaml to automatically do what is apparently enforced. I realize that we have github workflows that does the same check as well though.

@manics, what do you think? Reject this change and rely on github workflows, do both, or remove some logic from github workflows?