### PR TITLE
ci: use v1,v2,etc tags instead of branches for dependabot bumping compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,5 +39,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels:
-      - dependencies
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/release-updates.yml
+++ b/.github/workflows/release-updates.yml
@@ -1,6 +1,6 @@
 # Automatically updates "vX" branches based on GitHub releases. To cut a new
 # release, use the GitHub UI where you enter a tag name and release name of
-# "vX.Y.Z". See https://github.com/jupyterhub/action-k8s-namespace-report/releases.
+# "vX.Y.Z". See https://github.com/jupyterhub/action-major-minor-tag-calculator/releases.
 ---
 name: Release updates
 
@@ -15,11 +15,4 @@ jobs:
       contents: write
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
-      # NOTE: We pin a version not to have the source code (.ts files), but the
-      #       compiled source code (.js files). This git hash is what v2.0.1
-      #       referenced 30 December 2020.
       - uses: Actions-R-Us/actions-tagger@f411bd910a5ad370d4511517e3eac7ff887c90ea
-        with:
-          # By using branches as identifiers it is still possible to backtrack
-          # some patch, but not if we use tags.
-          prefer_branch_releases: true


### PR DESCRIPTION
- ci: declare time for gha dependabot bumps
- ci: use v1,v2,etc tags instead of branches
