### PR TITLE
dependabot: monthly updates of github actions and npm deps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# dependabot.yml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# dependabot.yaml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 #
 # Notes:
 # - Status and logs from dependabot are provided at

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,11 @@ updates:
       # "devDepenencies" on a monthly basis.
       - dependency-type: production
 
+  # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: github-actions
     directory: /
+    labels: [ci]
     schedule:
-      interval: weekly
+      interval: monthly
       time: "05:00"
-      timezone: "Etc/UTC"
+      timezone: Etc/UTC

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,30 +10,16 @@
 #
 version: 2
 updates:
-  # npm production dependencies
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    labels:
-      - maintenance
-      - dependencies
-    allow:
-      # To avoid PR noise, we only automate version bumps to the package.json's
-      # "dependencies", and ignore those in "devDependencies" on a weekly basis.
-      - dependency-type: production
-
-  # npm development dependencies
+  # npm dependencies
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC
     labels:
+      - maintenance
       - dependencies
-    allow:
-      # To avoid PR noise, we automate version bumps to the package.json's
-      # "devDepenencies" on a monthly basis.
-      - dependency-type: production
 
   # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: github-actions


### PR DESCRIPTION
This is one of several PRs opened in the juptyterhub github organization to systematically configure dependabot to update github actions on a monthly basis, for more information see https://github.com/jupyterhub/team-compass/issues/636.