### PR TITLE
Stop bumping dev deps and group production PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,11 +19,10 @@ updates:
       timezone: Etc/UTC
     allow:
       - dependency-type: production
+      - dependency-type: development
     groups:
-      production-dependencies:
-        dependency-type: production
-      development-dependencies:
-        dependency-type: development
+      all-dependencies:
+        patterns: ["*"]
     labels:
       - maintenance
       - dependencies

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# dependabot.yaml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Notes:
 # - Status and logs from dependabot are provided at
@@ -17,6 +17,13 @@ updates:
       interval: monthly
       time: "05:00"
       timezone: Etc/UTC
+    allow:
+      - dependency-type: production
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
     labels:
       - maintenance
       - dependencies


### PR DESCRIPTION
- Closes #316 by reducing the PR bump noise to at most one package.json bump PR a month, by no longer bumping dev dependencies, and grouping bumps of other dependencies.

Let's get this merged before November 1!